### PR TITLE
fix(windows): invoke Python Launcher with separate arguments

### DIFF
--- a/setup_windows.ps1
+++ b/setup_windows.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 =============================================================================
 Cybermes Windows Automated Setup & Installer
 Prepares local Windows environment, Python venv, dependencies & MCP tools
@@ -20,21 +20,24 @@ Write-Host "Directory: $CYBERMES_DIR" -ForegroundColor Gray
 Write-Host ""
 
 # 1. Check Python 3.10+
-$pythonCmd = $null
+$pythonExe = $null
+$pythonArgs = @()
 if (Get-Command python -ErrorAction SilentlyContinue) {
-    $pythonCmd = "python"
+    $pythonExe = "python"
 } elseif (Get-Command py -ErrorAction SilentlyContinue) {
-    $pythonCmd = "py -3"
+    $pythonExe = "py"
+    $pythonArgs = @("-3")
 }
 
-if (-not $pythonCmd) {
+if (-not $pythonExe) {
     Write-Host "❌ Error: Python is not installed or not in PATH." -ForegroundColor Red
     Write-Host "Please install Python 3.11+ from https://www.python.org/ and check 'Add Python to PATH'." -ForegroundColor Yellow
     exit 1
 }
 
-$pyVer = & $pythonCmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
-Write-Host "✓ Found Python $pyVer ($pythonCmd)" -ForegroundColor Green
+$pythonCommandDisplay = (@($pythonExe) + $pythonArgs) -join " "
+$pyVer = & $pythonExe @pythonArgs -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+Write-Host "✓ Found Python $pyVer ($pythonCommandDisplay)" -ForegroundColor Green
 
 # 2. Check Node.js / npm (Optional for MCP servers)
 if ((Get-Command node -ErrorAction SilentlyContinue) -and (Get-Command npm -ErrorAction SilentlyContinue)) {
@@ -55,7 +58,7 @@ if ((Get-Command node -ErrorAction SilentlyContinue) -and (Get-Command npm -Erro
 Write-Host ""
 Write-Host "📦 Setting up Python virtual environment (venv)..." -ForegroundColor Cyan
 if (-not (Test-Path "$CYBERMES_DIR\venv")) {
-    & $pythonCmd -m venv "$CYBERMES_DIR\venv"
+    & $pythonExe @pythonArgs -m venv "$CYBERMES_DIR\venv"
 }
 
 $venvPython = "$CYBERMES_DIR\venv\Scripts\python.exe"


### PR DESCRIPTION
## Description of Changes

Fix the Windows native installer when Python is available through the Python Launcher (`py`) but `python` is not on `PATH`.

The installer previously stored `py -3` as one string and invoked it through PowerShell's call operator. PowerShell resolves that as an executable named `py -3`, so setup fails before the virtual environment is created.

While validating the path on Windows PowerShell 5.1, I also found that the UTF-8 script needs a BOM: without it, the current Unicode output causes the script to fail parsing before execution. The BOM is included without changing the script's CRLF line endings.

### Changes

- Store the Python executable and arguments separately (`py` and `@('-3')`).
- Pass the argument array to both the Python version probe and `venv` creation.
- Add the UTF-8 BOM required for reliable parsing by Windows PowerShell 5.1.

### Target branch

`dev`

## Verification & Testing

- [x] Reproduced the original invocation failure on Windows PowerShell 5.1:
  `& 'py -3' --version` returns `The term 'py -3' is not recognized...`.
- [x] Verified the corrected invocation:
  `& py -3 --version` returns the installed Python version.
- [x] Simulated `python.exe` absent and `py.exe` available; the corrected selection ran the version probe and created a temporary venv successfully.
- [x] Parsed the patched `setup_windows.ps1` with the Windows PowerShell 5.1 parser: zero syntax errors.
- [x] Confirmed the unmodified `dev` file fails that parser check, while a BOM-only copy parses successfully.
- [x] `git diff --check` passes.
- [ ] Full dependency installation was not run; it would install the project's Python/npm dependencies.

## Security & Quality Checklist

- [x] No target data, credentials, or secrets included.
- [x] Testing was local and non-destructive.
- [x] Commit follows Conventional Commits.
- [x] Ready for maintainer review.
