### PR TITLE
fix(report): include target name in generated PDF filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ flowchart LR
 3. **High-Speed Stream Filtering (`smart_pipe`)**: Raw outputs are archived to disk in `recon/` while `smart_pipe` streams only relevant endpoints, HTTP status codes, and leaked secrets into Hermes' context window.
 4. **Hypothesis & Skill Retrieval**: Hermes queries the offline database (`search_knowledge`) and loads relevant offensive playbooks from `skills/`.
 5. **Deterministic PoC Validation Gate**: Hermes writes and executes a non-destructive script (`pocs/poc_<vuln>.py`), capturing raw HTTP request/response evidence.
-6. **Report Compilation**: Calls native Go `aggregate_reports` and `generate_pdf.py` to compile `SUMMARY.md`, `metadata.json`, interactive `report.html`, and `REPORT.pdf`.
+6. **Report Compilation**: Calls native Go `aggregate_reports` and `generate_pdf.py` to compile `SUMMARY.md`, `metadata.json`, interactive `report.html`, and `REPORT_<target>.pdf`.
 
 ---
 
@@ -259,7 +259,7 @@ flowchart LR
 | **LLM Token & Context Noise** | Fuzzer/crawler outputs flood context with thousands of lines of 404s and static assets. | **High-Speed Stream Filter (`smart_pipe`)**: Pure Go filter that archives raw logs to disk while streaming only high-signal endpoints, status codes, and secrets. |
 | **Exploit Verification** | Speculative or pattern-matched alerts without reproducible verification. | **Zero-False-Positive PoC Gate**: Requires standalone, non-destructive Python scripts (`pocs/poc_<name>.py`) and raw HTTP traces before logging findings. |
 | **Payload & Methodology Retrieval** | Manually searching external wikis, repositories, and cheat sheets online. | **Sub-50ms Local Knowledge Base (`search_knowledge`)**: Instant offline query engine across 200+ SOP playbooks, PayloadsAllTheThings, and HackTricks datasets. |
-| **Structured Deliverables** | Unorganized text dumps requiring tedious manual report compilation. | **Multi-Format Report Aggregator**: Automated generation of `SUMMARY.md`, `metadata.json`, standalone interactive HTML, and print-ready `REPORT.pdf`. |
+| **Structured Deliverables** | Unorganized text dumps requiring tedious manual report compilation. | **Multi-Format Report Aggregator**: Automated generation of `SUMMARY.md`, `metadata.json`, standalone interactive HTML, and print-ready `REPORT_<target>.pdf`. |
 | **OS & Environment Portability** | Most offensive tools assume Kali/Linux, complicating Windows setups. | **Native Multi-Platform Support**: Automated native installers for Windows (PowerShell), Linux, macOS, and Docker with a built-in health check and repair tool (`doctor.py`). |
 
 ---
@@ -271,7 +271,7 @@ flowchart LR
 - **200+ Offensive Playbooks**: Standard operating procedures in `skills/` covering API security (IDOR/BOLA, JWT, BPLA), web vulnerabilities (SSRF, XSS, SQLi, Race Conditions), and cloud misconfigurations.
 - **Integrated Reconnaissance**: Pre-configured pipelines for `subfinder`, `httpx`, `katana`, `ffuf`, `nuclei`, and `sqlmap`.
 - **Target Workspace Isolation**: Strict target-scoped evidence tracking, preventing context contamination across engagements.
-- **Multi-Format Reporting**: Automated output generation in Markdown (`SUMMARY.md`), JSON metrics (`metadata.json`), standalone HTML dashboards, and PDF reports (`REPORT.pdf`).
+- **Multi-Format Reporting**: Automated output generation in Markdown (`SUMMARY.md`), JSON metrics (`metadata.json`), standalone HTML dashboards, and PDF reports (`REPORT_<target>.pdf`).
 - **Cross-Platform Compatibility**: Fully supported on Windows (native PowerShell), Linux, macOS, and Docker.
 
 ---
@@ -286,7 +286,7 @@ Cybermes/
 │   ├── SUMMARY.md                # Consolidated executive findings matrix
 │   ├── metadata.json             # Structured JSON metrics & counters
 │   ├── report.html               # Standalone interactive HTML report
-│   ├── REPORT.pdf                # Print-ready PDF report
+│   ├── REPORT_<target>.pdf       # Print-ready PDF report (named per assessed target)
 │   ├── findings/                 # Confirmed vulnerability writeups (low, medium, high, critical)
 │   │   └── high_idor_orders.md
 │   ├── pocs/                     # Standalone Python proof-of-concept scripts

--- a/cmd/aggregate_reports/main.go
+++ b/cmd/aggregate_reports/main.go
@@ -85,6 +85,6 @@ func main() {
 		fmt.Printf("  Dashboard: reports/%s/report.html\n", summary.Target)
 	}
 	if artifacts != nil && artifacts.PDFGenerated {
-		fmt.Printf("  Executive PDF: reports/%s/REPORT.pdf\n", summary.Target)
+		fmt.Printf("  Executive PDF: reports/%s/REPORT_%s.pdf\n", summary.Target, summary.Target)
 	}
 }

--- a/docs/tools_and_skills.md
+++ b/docs/tools_and_skills.md
@@ -94,7 +94,7 @@ python tools/generate_pdf.py --no-pdf
 
 Outputs generated in `reports/<TARGET_SLUG>/`:
 - `report.html`: Standalone interactive HTML dashboard with Dark/Light theme toggle.
-- `REPORT.pdf`: Executive printable PDF with CVSS badges, risk charts, and PoC breakdown.
+- `REPORT_<target>.pdf`: Executive printable PDF with CVSS badges, risk charts, and PoC breakdown.
 
 ---
 

--- a/pkg/mcp/tools_reports.go
+++ b/pkg/mcp/tools_reports.go
@@ -19,14 +19,14 @@ var slugRegex = regexp.MustCompile(`[^a-z0-9]+`)
 func (s *Server) registerReportsTools() {
 	aggTool := mcp.NewTool(
 		"cybermes_aggregate_report",
-		mcp.WithDescription("Aggregate vulnerability findings, PoC scripts, and evidence files for a target (or all targets) into executive SUMMARY.md, metadata.json, report.html, and REPORT.pdf."),
+		mcp.WithDescription("Aggregate vulnerability findings, PoC scripts, and evidence files for a target (or all targets) into executive SUMMARY.md, metadata.json, report.html, and REPORT_<target>.pdf."),
 		mcp.WithString(
 			"target_slug",
 			mcp.Description("Target slug/directory name in reports/ (e.g. 'example_com', '127_0_0_1_8888'). If empty or 'all', aggregates all targets."),
 		),
 		mcp.WithBoolean(
 			"generate_pdf",
-			mcp.Description("Whether to automatically render optional REPORT.pdf via Chrome DevTools Protocol (default: false)."),
+			mcp.Description("Whether to automatically render optional REPORT_<target>.pdf via Chrome DevTools Protocol (default: false)."),
 			mcp.DefaultBool(false),
 		),
 		mcp.WithString(
@@ -187,7 +187,7 @@ func (s *Server) handleAggregateReport(ctx context.Context, request mcp.CallTool
 		sb.WriteString(fmt.Sprintf("- **Interactive Dashboard**: `reports/%s/report.html`\n", summary.Target))
 	}
 	if artifacts != nil && artifacts.PDFGenerated {
-		sb.WriteString(fmt.Sprintf("- **Executive PDF**: `reports/%s/REPORT.pdf`\n", summary.Target))
+		sb.WriteString(fmt.Sprintf("- **Executive PDF**: `reports/%s/REPORT_%s.pdf`\n", summary.Target, summary.Target))
 	} else if artifacts != nil && artifacts.ErrorMessage != "" {
 		sb.WriteString(fmt.Sprintf("- **PDF Status**: Not generated (%s)\n", artifacts.ErrorMessage))
 	}
@@ -225,7 +225,7 @@ func (s *Server) handleGeneratePDF(ctx context.Context, request mcp.CallToolRequ
 	sb.WriteString(fmt.Sprintf("- **HTML Dashboard**: `reports/%s/report.html`\n", targetSlug))
 
 	if artifacts.PDFGenerated {
-		sb.WriteString(fmt.Sprintf("- **Executive PDF**: `reports/%s/REPORT.pdf`\n", targetSlug))
+		sb.WriteString(fmt.Sprintf("- **Executive PDF**: `reports/%s/REPORT_%s.pdf`\n", targetSlug, targetSlug))
 		if artifacts.BrowserUsed != "" {
 			sb.WriteString(fmt.Sprintf("- **Browser Engine**: `%s`\n", artifacts.BrowserUsed))
 		}

--- a/pkg/report/aggregator.go
+++ b/pkg/report/aggregator.go
@@ -124,7 +124,7 @@ func AggregateTarget(targetDir string) (*SummaryData, error) {
 	return summaryData, nil
 }
 
-// AggregateTargetWithPDF aggregates findings, generates SUMMARY.md, metadata.json, report.html, and optionally REPORT.pdf
+// AggregateTargetWithPDF aggregates findings, generates SUMMARY.md, metadata.json, report.html, and optionally REPORT_<target>.pdf
 func AggregateTargetWithPDF(targetDir string, generatePDF bool) (*SummaryData, *ReportArtifacts, error) {
 	summaryData, err := AggregateTarget(targetDir)
 	if err != nil {

--- a/pkg/report/pdf.go
+++ b/pkg/report/pdf.go
@@ -174,12 +174,12 @@ func RenderPDF(htmlPath string, pdfPath string) (string, error) {
 	return browserPath, nil
 }
 
-// GenerateFullReport generates SUMMARY.md, metadata.json, report.html, and optionally REPORT.pdf
+// GenerateFullReport generates SUMMARY.md, metadata.json, report.html, and optionally REPORT_<target>.pdf
 func GenerateFullReport(targetDir string, data *SummaryData, generatePDF bool) (*ReportArtifacts, error) {
 	targetName := filepath.Base(targetDir)
 	summaryPath := filepath.Join(targetDir, "SUMMARY.md")
 	metaPath := filepath.Join(targetDir, "metadata.json")
-	pdfPath := filepath.Join(targetDir, "REPORT.pdf")
+	pdfPath := filepath.Join(targetDir, fmt.Sprintf("REPORT_%s.pdf", targetName))
 
 	artifacts := &ReportArtifacts{
 		Target:       targetName,
@@ -195,7 +195,7 @@ func GenerateFullReport(targetDir string, data *SummaryData, generatePDF bool) (
 	}
 	artifacts.HTMLPath = htmlPath
 
-	// 2. Generate REPORT.pdf if requested
+	// 2. Generate REPORT_<target>.pdf if requested
 	if generatePDF {
 		browserUsed, err := RenderPDF(htmlPath, pdfPath)
 		if err != nil {

--- a/tools/generate_pdf.py
+++ b/tools/generate_pdf.py
@@ -462,7 +462,7 @@ def generate_report_for_target(target_dir: Path, output_pdf: bool = True) -> tup
     except Exception:
         pass
 
-    pdf_file = target_dir / "REPORT.pdf"
+    pdf_file = target_dir / f"REPORT_{target_dir.name}.pdf"
 
     if output_pdf:
         try:


### PR DESCRIPTION
## Description of Changes

Previously every executive report rendered to a fixed `REPORT.pdf`, so PDFs from different assessments collided (same filename in every `reports/<target>/` folder) and downloaded files were indistinguishable from each other.

The PDF filename now includes the sanitized target slug: `REPORT_<target>.pdf` (e.g. `REPORT_example_com.pdf`).

### Type of Change
- [x] Bug fix (non-breaking change fixing an existing issue)
- [ ] New feature (non-breaking change adding new functionality or tool)
- [ ] Documentation / Skill reference update
- [ ] Performance / Docker runtime optimization
- [ ] Code refactor or maintenance

### Files changed
- `pkg/report/pdf.go`: generate `REPORT_<target>.pdf` instead of `REPORT.pdf`
- `pkg/report/aggregator.go`: comment updated
- `cmd/aggregate_reports/main.go`: CLI output reflects new filename
- `pkg/mcp/tools_reports.go`: MCP tool descriptions + result strings updated
- `tools/generate_pdf.py`: standalone Python generator renamed likewise
- `README.md`, `docs/tools_and_skills.md`: documented artifact name updated

---

## Verification & Testing

- [x] Code passes test and compilation checks (`go test ./pkg/... -v`, `python3 -m py_compile ...`)
  - `go build ./...` clean, `go vet` clean, `go test ./pkg/...` all packages ok, `py_compile` pass
- [x] Tested locally on target / mock application
  - Ran `tools/generate_pdf.py` on an existing local report folder: produced `REPORT_<target>.pdf` as expected
- [x] No regression on existing core tools (`smart_pipe`, `secret_scan`, `search_knowledge`, `aggregate_reports`, etc.)
  - Full `./pkg/...` suite passes; `aggregate_reports` builds and its output paths updated consistently

---

## Security & Quality Checklist

- [x] **Zero Target Data**: Verified that NO real domains, production IPs, live credentials, or confidential target details are present.
- [x] **Safe Testing**: Changes adhere to non-destructive testing principles.
- [x] **Clean Commits**: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Ready for maintainer review.