### PR TITLE
chore(ci): run the pipeline on dev, the branch CONTRIBUTING requires pull requests to target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   go-ci:


### PR DESCRIPTION
## 📝 Description of Changes

`CONTRIBUTING.md` asks that every pull request be branched from and targeted against `dev`, and that `main` receive `dev` only after complete testing. The CI workflow triggers on `push` and `pull_request` for `main` alone, so the branch the guide requires contributors to use is the one branch the pipeline does not watch.

The practical effect is that a pull request against `dev` runs no checks at all. `go test -v -race ./pkg/...`, the binary build, the Python compile step, the skills validation, the MCP package tests and the Dockerfile validation all run for the first time when `dev` is merged into `main`, which is after the review decision rather than before it. A reviewer looking at a contributor's pull request sees no status checks and has nothing mechanical to lean on.

This adds `dev` to both triggers so the mandated contribution branch is covered by the same pipeline as `main`. It changes no job, no step and no version, and it costs one extra run per push to `dev`.

I have kept this to the single change so it is easy to reject or amend. If you would rather the pipeline stayed lean on `dev`, an alternative is to trigger only `pull_request` on `dev` and leave `push` to `main`, which still gives contributors a green or red check without doubling the runs on your own pushes.

This pull request will itself show no status checks, because it targets `dev`, which is the gap it addresses.

### 🎯 Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an existing issue)
- [ ] ✨ New feature (non-breaking change adding new functionality or tool)
- [ ] 📚 Documentation / Skill reference update
- [ ] ⚡ Performance / Docker runtime optimization
- [x] 🧹 Code refactor or maintenance

---

## 🧪 Verification & Testing

- [ ] Code passes test and compilation checks (`go test ./pkg/... -v`, `python3 -m py_compile ...`)
- [ ] Tested locally on target / mock application
- [ ] No regression on existing core tools (`smart_pipe`, `secret_scan`, `search_knowledge`, `aggregate_reports`, etc.)

Left unticked on purpose: no Go, Python or tool code is touched by this change, and by construction the pipeline cannot run on this pull request yet. The GitHub editor showed no syntax warning on the final file.

---

## 🛡️ Security & Quality Checklist

- [x] **Zero Target Data**: Verified that NO real domains, production IPs, live credentials, or confidential target details are present.
- [x] **Safe Testing**: Changes adhere to non-destructive testing principles.
- [x] **Clean Commits**: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Ready for maintainer review.