### PR TITLE
fix(docker): fail the build when a piped setup step fails, and retry transient mirror errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:24.04
 
 ARG TARGETARCH
+# A RUN step must fail when any command in a pipe fails, not only the last one.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -11,6 +13,9 @@ ENV PATH="/opt/hermes-venv/bin:/usr/local/bin:/workspace/tools/bin:${PATH}"
 ENV HERMES_HOME=/root/.hermes
 
 WORKDIR /workspace
+
+# Retry a transient mirror failure instead of continuing with a broken index.
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 
 # 1. Essential runtime packages, network tools, and Chrome/Playwright dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -57,6 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 2. Node.js LTS & MCP servers
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
+    node --version && npm --version && \
     npm install -g @modelcontextprotocol/server-puppeteer @modelcontextprotocol/server-filesystem && \
     npm cache clean --force && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### 📝 Description of Changes

The `Dockerfile Lint & Validate` job is currently red on `dev`, and the cause is a transient network failure that the build does not notice until several minutes later, in a step that has nothing to do with it.

What the log of run `33935746168` (commit `a16e30b`) shows, in order:

1. Layer 4 starts. `curl -fsSL https://deb.nodesource.com/setup_22.x | bash -` runs.
2. The NodeSource script hits a broken mirror index: `E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/noble-updates/restricted/binary-amd64/Packages.gz Hash Sum mismatch`.
3. The script reports the failure and exits successfully anyway. Its own words: `Error: Failed to run 'apt update' (Exit Code: 0)`.
4. The `&&` chain therefore continues. `apt-get install -y --no-install-recommends nodejs` fetches 12.6 MB and returns 0.
5. `npm install -g ...` fails with `/bin/sh: 1: npm: not found`, exit code 127, and the build aborts.

So a mirror hiccup in step 2 surfaces as a missing binary in step 5. The same `Dockerfile` built successfully six minutes earlier on `d98d8f5`, and the run before that failed the same way on `23fb263`. It is intermittent rather than broken, which is the harder kind to diagnose from a red check.

Three small changes, none of which alter behaviour on a successful build:

**`SHELL` with `pipefail`.** The default `/bin/sh -c` returns the exit status of the last command in a pipe, so `curl ... | bash -` reports whatever `bash` returned and a failed download is invisible. With `pipefail` the layer fails at step 2, where the actual problem is, with the actual error message. This also covers the `wget ... | gpg --dearmor` pipe in the layer above, where a failed key download currently produces an empty keyring and an apt failure further on.

**`Acquire::Retries "3"`.** A `Hash Sum mismatch` is usually a mirror that is mid-sync. Retrying is the standard remedy and costs nothing when the first attempt works.

**`node --version && npm --version`.** An explicit check that the toolchain the next command needs is actually present, so the failure names the missing thing instead of surfacing as `command not found`.

I kept this to the smallest change that addresses the observed failure. Happy to drop any of the three, or to split them.

**On open pull requests that touch the same file.** #30 (`bump ubuntu from 24.04 to 26.04`) also edits the `Dockerfile`. It changes the `FROM` line; this changes three other places, so the two should merge cleanly, and if #30 lands first I will rebase rather than expect you to resolve it. Nothing here settles that upgrade either way. The other nine open dependency pull requests do not touch this file. I mention it because a change that quietly invalidates an open review is worse than no change at all.

*(Unrelated to this change, but visible in the same log and worth a separate look when you have time: layer 3 takes 3014 s, of which roughly 1900 s is the Chrome install and its `systemd` dependency chain. The whole job runs 44 to 70 minutes. A multi-stage build, or `--no-install-recommends` on the Chrome branch, would likely cut most of it.)*

### 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change fixing an existing issue)
- [ ] ✨ New feature (non-breaking change adding new functionality or tool)
- [ ] 📚 Documentation / Skill reference update
- [ ] ⚡ Performance / Docker runtime optimization
- [ ] 🧹 Code refactor or maintenance

---

### 🧪 Verification & Testing

- [ ] Code passes test and compilation checks (`go test ./pkg/... -v`, `python3 -m py_compile ...`)
- [ ] Tested locally on target / mock application
- [ ] No regression on existing core tools (`smart_pipe`, `secret_scan`, `search_knowledge`, `aggregate_reports`, etc.)

Left unticked, and I would rather say so than tick them: **I have no Docker daemon on this machine, so I have not built this image.** No Go, Python or tool code is touched. What I did verify is the shell semantics the change relies on, on `GNU bash 5.3.9`:

```
$ bash -c 'set -o pipefail; false | true' ; echo $?
1
$ bash -c 'set +o pipefail; false | true' ; echo $?
0
```

That is exactly the difference between the current build silently continuing after a failed `curl` and the layer stopping where the problem is. The `Acquire::Retries` and `--version` lines are inert on a healthy build. Since the failure is intermittent, a single green run would not prove much either way; the CI on `dev` will tell you more over the next few pushes than my machine could.

---

### 🛡️ Security & Quality Checklist

- [x] **Zero Target Data**: Verified that NO real domains, production IPs, live credentials, or confidential target details are present.
- [x] **Safe Testing**: Changes adhere to non-destructive testing principles.
- [x] **Clean Commits**: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Ready for maintainer review.