### PR TITLE
fix(setup_mcp): add missing `import re` so the JSONC fallback parser works

### DIFF
--- a/scripts/setup_mcp.py
+++ b/scripts/setup_mcp.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import os
 import platform
+import re
 import shutil
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Problem

`scripts/setup_mcp.py` never imports `re`, but `safe_read_json()` uses it in the JSONC fallback path:

```python
# scripts/setup_mcp.py:53-69
def safe_read_json(file_path: Path):
    ...
    try:
        return json.loads(content)
    except Exception:
        # Strip comments while preserving strings with quotes
        cleaned = re.sub(r'("(?:\.|[^"\])*")|//.*$|/\*[\s\S]*?\*/', ..., flags=re.MULTILINE)
        cleaned = re.sub(r',\s*([}\]])', r'\1', cleaned)
        return json.loads(cleaned)
except Exception as e:
    return {"_parseError": str(e)}
```

Imports at the top are `argparse, datetime, json, os, platform, shutil, sys, pathlib` — no `re`.

So the fallback raises `NameError`, the outer `except Exception as e` swallows it, and the function returns `{"_parseError": "name 're' is not defined"}`.

## Impact

The fallback exists precisely for client configs that are JSONC (comments / trailing commas) — Zed, Continue, Cline, VS Code-family settings. For exactly those files the installer now reports a bogus error instead of parsing them. Every caller treats `_parseError` as fatal:

```python
# lines 268-270, 286-288, 316-318, 341-343
data = safe_read_json(file_path)
if data and "_parseError" in data:
    return {"status": "error", "details": f"Invalid JSON: {data['_parseError']}"}
```

and `--status` / `--uninstall` (lines 404-416) bail out the same way. Result:

```
Invalid JSON: name 're' is not defined
```

## Verification

Ran the real module (unmodified vs. patched) against a JSONC config:

```
[UNPATCHED] safe_read_json -> {"_parseError": "name 're' is not defined"}
[UNPATCHED] caller reports: {"status":"error","details":"Invalid JSON: name 're' is not defined"}
[PATCHED]   safe_read_json -> {"context_servers": {"foo": {"command": "bar"}}}
[PATCHED]   caller proceeds, keys=['context_servers']
```

## Fix

One added stdlib import. No behaviour change for configs that are already strict JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
